### PR TITLE
Bugfix: Replace JSON behavior GlobalObjectID's with newly created GameObject GlobalObjectID's when loading/deserializing

### DIFF
--- a/UnityBehaviorBugReports/Assets/Samples/Behavior/1.0.2/Runtime Serialization/Additional Scripts/SerializationHelper.cs
+++ b/UnityBehaviorBugReports/Assets/Samples/Behavior/1.0.2/Runtime Serialization/Additional Scripts/SerializationHelper.cs
@@ -32,12 +32,18 @@ public static class SerializationHelper
         Debug.Log(report.ToString());
     }
 
-    public static void PrintGlobalObjectIDs(List<Object> objects)
+    public static List<string> PrintGlobalObjectIDs(List<Object> objects)
     {
+        List<string> results = new();
+        
         foreach (Object o in objects)
         {
             GlobalObjectId globalID = GlobalObjectId.GetGlobalObjectIdSlow(o);
             Debug.Log($"Object: {o}, GlobalObjectID: {globalID}", o);
+            
+            results.Add(globalID.ToString());
         }
+
+        return results;
     }
 }

--- a/UnityBehaviorBugReports/Assets/Samples/Behavior/1.0.2/Runtime Serialization/Additional Scripts/SerializationHelper.cs
+++ b/UnityBehaviorBugReports/Assets/Samples/Behavior/1.0.2/Runtime Serialization/Additional Scripts/SerializationHelper.cs
@@ -39,7 +39,7 @@ public static class SerializationHelper
         foreach (Object o in objects)
         {
             GlobalObjectId globalID = GlobalObjectId.GetGlobalObjectIdSlow(o);
-            Debug.Log($"Object: {o}, GlobalObjectID: {globalID}", o);
+            Debug.Log($"'{globalID}' is {o}", o);
             
             results.Add(globalID.ToString());
         }

--- a/UnityBehaviorBugReports/Assets/Samples/Behavior/1.0.2/Runtime Serialization/SerializationExampleSceneController.cs
+++ b/UnityBehaviorBugReports/Assets/Samples/Behavior/1.0.2/Runtime Serialization/SerializationExampleSceneController.cs
@@ -119,6 +119,8 @@ namespace Unity.Behavior.SerializationExample
             }
 
             m_savedThisSession = true;
+            
+            PrintJSONGlobalObjectIDs();
         }
 
         [Button]
@@ -153,6 +155,7 @@ namespace Unity.Behavior.SerializationExample
             }
         }
 
+        [Button]
         private void PrintJSONGlobalObjectIDs()
         {
             // Allocate
@@ -176,8 +179,17 @@ namespace Unity.Behavior.SerializationExample
                 // Otherwise, GlobalObjectId struct is valid...
                 else
                 {
-                    // Print
-                    Debug.Log(id);
+                    Object obj = GlobalObjectId.GlobalObjectIdentifierToObjectSlow(id);
+
+                    if (obj != null)
+                    {
+                        // Print
+                        Debug.Log("'" + id + "' is " + obj.name, obj);
+                    }
+                    else
+                    {
+                        Debug.Log(id);
+                    }
                 }
             }
         }

--- a/UnityBehaviorBugReports/Assets/Samples/Behavior/1.0.2/Runtime Serialization/SerializationExampleSceneController.cs
+++ b/UnityBehaviorBugReports/Assets/Samples/Behavior/1.0.2/Runtime Serialization/SerializationExampleSceneController.cs
@@ -136,8 +136,8 @@ namespace Unity.Behavior.SerializationExample
                 Debug.Log("Printing save data GlobalObjectID's...");
                 PrintJSONGlobalObjectIDs();
 
-                Debug.Log("Printing current agent GlobalObjectIDs...");
-                List<string> currentIDs = new(PrintAgentGlobalObjectIDs());
+                Debug.Log("Printing current QueueSlot GlobalObjectIDs...");
+                List<string> currentIDs = PrintQueueSlotGlobalObjectIDs();
 
                 Debug.Log("Now replacing save data GlobalObjectID's with current GlobalObjectIDs...");
                 ReplaceJSONGlobalObjectIDs(currentIDs);
@@ -295,16 +295,21 @@ namespace Unity.Behavior.SerializationExample
             }
         }
 
-        [Button("Print Agent GlobalObjectID's")]
-        private List<string> PrintAgentGlobalObjectIDs()
+        private List<string> PrintGlobalObjectIDs(List<Object> objects)
         {
-            if (m_agents.Count <= 0)
+            if (objects.Count <= 0)
             {
-                Debug.LogWarning("No agents found. Unable to print agent GlobalObjectID's.");
+                Debug.LogWarning("Unable to print GlobalObjectID's. No provided objects found.");
                 return new();
             }
-            
-            return SerializationHelper.PrintGlobalObjectIDs(new List<Object>(m_agents));
+
+            return SerializationHelper.PrintGlobalObjectIDs(objects);
+        }
+
+        [Button("Print QueueSlot GlobalObjectID's")]
+        private List<string> PrintQueueSlotGlobalObjectIDs()
+        {
+            return PrintGlobalObjectIDs(new List<Object>(m_queueSlots));
         }
     }
 }


### PR DESCRIPTION
Fixes #1.

This PR is an implementation of the proposed solution: https://discussions.unity.com/t/behavior-errors-deserializing-behaviorgraph-json-after-re-creating-related-gameobjects/1534184/2

While this does fix issue #1 and allows us to get a valid object reference now, it does bring up a new assertion on deserialization which still ultimately fails.

### New Call Stack
```C#
InvalidCastException: Specified cast is not valid.
Unity.Behavior.Serialization.Json.DeserializationResult.Throw () (at ./Library/PackageCache/com.unity.behavior/com.unity.serialization/Runtime/Unity.Serialization/Json/JsonSerialization+FromJson.cs:121)
Unity.Behavior.Serialization.Json.JsonSerialization.FromJsonOverride[T] (System.String json, T& container, Unity.Behavior.Serialization.Json.JsonSerializationParameters parameters) (at ./Library/PackageCache/com.unity.behavior/com.unity.serialization/Runtime/Unity.Serialization/Json/JsonSerialization+FromJson.cs:236)
Unity.Behavior.RuntimeSerializationUtility+JsonBehaviorSerializer.Deserialize (System.String graphJson, Unity.Behavior.BehaviorGraph graph, Unity.Behavior.RuntimeSerializationUtility+IUnityObjectResolver`1[TSerializedFormat] resolver) (at ./Library/PackageCache/com.unity.behavior/Runtime/Utilities/RuntimeSerializationUtility.cs:139)
Unity.Behavior.BehaviorGraphAgent.Deserialize[TSerializedFormat] (TSerializedFormat serialized, Unity.Behavior.RuntimeSerializationUtility+IBehaviorSerializer`1[TSerializedFormat] serializer, Unity.Behavior.RuntimeSerializationUtility+IUnityObjectResolver`1[TSerializedFormat] resolver) (at ./Library/PackageCache/com.unity.behavior/Runtime/Execution/Components/BehaviorGraphAgent.cs:359)
Unity.Behavior.SerializationExample.SerializationExampleSceneController.Load () (at Assets/Samples/Behavior/1.0.2/Runtime Serialization/SerializationExampleSceneController.cs:152)
Unity.Behavior.SerializationExample.SerializationExampleSceneController.OnGUI () (at Assets/Samples/Behavior/1.0.2/Runtime Serialization/SerializationExampleSceneController.cs:95)
```

~~Hopefully this type cast error is fixed in `com.unity.behavior` - `v1.0.3` as described here: https://discussions.unity.com/t/behavior-errors-deserializing-behaviorgraph-json-after-re-creating-related-gameobjects/1534184/3~~
~~Might be related to #2.~~

Isn't related to #2 